### PR TITLE
Allow argument specifying tag beyond latest

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,5 @@
-FROM alpine:edge
+ARG VERSION=edge
+FROM alpine:$VERSION
 
 MAINTAINER JAremko <w3techplaygound@gmail.com>
 

--- a/Dockerfile.emacs24
+++ b/Dockerfile.emacs24
@@ -1,4 +1,5 @@
-FROM ubuntu:latest
+ARG VERSION=latest
+FROM ubuntu:$VERSION
 
 MAINTAINER JAremko <w3techplaygound@gmail.com>
 

--- a/Dockerfile.emacs25
+++ b/Dockerfile.emacs25
@@ -1,4 +1,5 @@
-FROM ubuntu:latest
+ARG VERSION=latest
+FROM ubuntu:$VERSION
 
 MAINTAINER JAremko <w3techplaygound@gmail.com>
 

--- a/Dockerfile.snapshot
+++ b/Dockerfile.snapshot
@@ -1,4 +1,5 @@
-FROM ubuntu:latest
+ARG VERSION=latest
+FROM ubuntu:$VERSION
 
 MAINTAINER JAremko <w3techplaygound@gmail.com>
 


### PR DESCRIPTION
This change will allow pinning to an ubuntu version and not just latest. Of course this could just be forked or copied into a Dockerfile but the docs recommend using this as a base for spacemacs-docker.

Not sure what your min requirement for docker is, this is a somewhat new feature.