### PR TITLE
Fix script error when user does not exist

### DIFF
--- a/asEnvUser
+++ b/asEnvUser
@@ -29,7 +29,7 @@ fi
 if [ -d "${UHOME}" ]
 then
   home_owner="$(stat --format '%U' ${UHOME})"
-  if [ $(id -u ${UNAME}) -ne $(id -u ${home_owner}) ]; then
+  if ! id "${home_owner}" >/dev/null 2>&1 || [ "$(id -u ${UNAME})" -ne "$(id -u ${home_owner})" ]; then
     chown "${UID}":"${GID}" -R ${UHOME}
   fi
 else


### PR DESCRIPTION
If the owner of ~UHOME as an uid which doesn't exist in the container,
$home_owner is going to be "UNKNOWN" and 'id -u UNKNOWN' will return an
error:

```
  id: 'UNKNOWN': no such user
  /usr/local/sbin/asEnvUser: line 32: [: 1033: unary operator expected
```

It happens when for instance your host uid is 1033 and you set UID=1033,
1033 doesn't exist in the container and fail.